### PR TITLE
Automatic build and deploy to now.sh

### DIFF
--- a/.nowignore
+++ b/.nowignore
@@ -1,0 +1,3 @@
+node_modules
+public
+.cache

--- a/now.json
+++ b/now.json
@@ -1,0 +1,16 @@
+{
+  "version": 2,
+  "name": "neontribe-www",
+  "alias": ["neontribe.now.sh"],
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@now/static-build",
+      "config": {
+        "distDir": "public",
+        "useBuildUtils": "@now/build-utils@canary"
+      }
+    }
+  ],
+  "regions": ["bru1"]
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "develop": "gatsby develop",
     "start": "npm run develop",
     "format": "prettier --write \"src/**/*.js\"",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "now-build": "npm run build"
   },
   "devDependencies": {
     "prettier": "^1.15.2"

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
With this configuration every PR will get a build and deploy for each commit, with a status message on the PR page pointing to the deployment location.

Additionally, commits on `master` will be built onto `https://neontribe.now.sh` once this is merged. I've done a manual release of master to `https://neontribe.now.sh` for the meanwhile.

Details:

So... I did this using v2 of the now.sh platform which has a great deal of promise. 

* The running costs are very low (we can reasonably expect free for neontribe.co.uk's volume of traffic)
* The branch-based deployments are also trivial to set up
* It is very modern in design (everything is a lambda)
* It gives us room to grow in many directions should we need it
* v1 is immensely loved and, by mot accounts, rock solid

Downsides:

v2 of now.sh is beta. It shows. I've seen more bugs than I'd like already and have even been moved to submit PRs against their examples. The docs are a little vague. They've been a bit too ambitions in suggesting existing customers move to the new platform already, and so they've got some pissed off folk around. I have high confidence that they'll improve the situation rapidly.

If my confidence is misplaced I volunteer to move us over to v1, or even elsewhere.
