### PR TITLE
fix: perspective 3d transform rule

### DIFF
--- a/src/components/FlipCard.js
+++ b/src/components/FlipCard.js
@@ -62,6 +62,7 @@ const cardSideStyles = css`
     position: relative;
     z-index: 1;
     backface-visibility: hidden;
+    transform-style: preserve-3d;
   }
 
   .card-side + .card-side {


### PR DESCRIPTION
Fixes #226

Flipping bios in Firefox show the back face correctly
