### PR TITLE
174 - add partiallyActive prop to nav links

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -34,7 +34,11 @@ const activeLinkStyles = css.resolve`
 `
 
 const NavLink = ({ children, active, ...props }) => (
-  <Link {...props} activeClassName={activeLinkStyles.className}>
+  <Link
+    {...props}
+    activeClassName={activeLinkStyles.className}
+    partiallyActive={true}
+  >
     <Text lineHeight={2} weight={500}>
       {children}
     </Text>


### PR DESCRIPTION
- The links were not setting the active styles when the URL contained a trailing slash.
- Setting the `partiallyActive` prop to true means trailing slashes and sub-pages trigger the `isActive` state: https://www.gatsbyjs.org/docs/gatsby-link/#show-active-styles-for-partially-matched-and-parent-links

Fixes #174