### PR TITLE
fix #228: add a loading indicator

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -3,5 +3,40 @@
  *
  * See: https://www.gatsbyjs.org/docs/browser-apis/
  */
+import React from 'react'
+import Loading from './src/components/Loading'
+import { globalHistory } from '@reach/router'
+import CustomEvent from 'custom-event'
 
 require('./prism-theme.css')
+
+let lastHref
+
+const setProgress = ename => {
+  const progEvent = new CustomEvent(ename, {
+    bubbles: true,
+  })
+  dispatchEvent(progEvent)
+}
+
+globalHistory.listen(event => {
+  if (event.location.href === lastHref) return
+
+  lastHref = event.location.href
+  setProgress('startLoad')
+})
+
+var onRouteUpdate = () => {
+  setProgress('endLoad')
+}
+
+var wrapPageElement = ({ element }) => {
+  return (
+    <>
+      <Loading />
+      <div id="mainPage">{element}</div>
+    </>
+  )
+}
+
+export { onRouteUpdate, wrapPageElement }

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -5,3 +5,5 @@
  */
 
 // You can delete this file if you're not using it
+
+export { wrapPageElement } from './gatsby-browser'

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "dependencies": {
     "classnames": "2.2.6",
+    "custom-event": "1.0.1",
     "date-fns": "1.30.1",
     "gatsby": "2.9.0",
     "gatsby-image": "2.1.3",
@@ -27,6 +28,7 @@
     "react": "16.8.6",
     "react-dom": "16.8.6",
     "react-helmet": "5.2.1",
+    "react-loading-bar": "0.0.7",
     "react-malarquee": "0.0.13",
     "rehype-react": "3.1.0",
     "slugify": "1.3.4",

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -9,6 +9,7 @@ import Link from './Link'
 import Text from './Text'
 import ConstrainedWidth from './Layout/ConstrainedWidth'
 import { ExternalLink } from './Link'
+import Loading from './Loading'
 
 const activeLinkStyles = css.resolve`
   a {

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -47,8 +47,8 @@ const Layout = ({ children }) => (
 
       html,
       body,
-      body > div,
-      body > div > div {
+      #___gatsby,
+      #___gatsby #mainPage {
         height: 100%;
       }
       *,

--- a/src/components/Loading/index.js
+++ b/src/components/Loading/index.js
@@ -1,0 +1,30 @@
+import React, { useState, useEffect } from 'react'
+import LoadingBar from 'react-loading-bar'
+import 'react-loading-bar/dist/index.css'
+import { c_LOADING } from '../../theme'
+
+const Loading = () => {
+  const [show, setShow] = useState(false)
+
+  const startLoadListener = () => {
+    setShow(true)
+  }
+
+  const endLoadListener = () => {
+    setShow(false)
+  }
+
+  useEffect(() => {
+    addEventListener('startLoad', startLoadListener) // eslint-disable-line no-restricted-globals
+    addEventListener('endLoad', endLoadListener) // eslint-disable-line no-restricted-globals
+
+    return () => {
+      removeEventListener('startLoad', startLoadListener) // eslint-disable-line no-restricted-globals
+      removeEventListener('endLoad', endLoadListener) // eslint-disable-line no-restricted-globals
+    }
+  })
+
+  return <LoadingBar show={show} color={c_LOADING} />
+}
+
+export default Loading

--- a/src/theme.js
+++ b/src/theme.js
@@ -83,6 +83,7 @@ export const c_SECONDARY_BACKGROUND = c_WHITE
 export const c_CALL_TO_ACTION = c_NEON_PURPLE
 export const c_LOGO_BACKGROUND = c_WHITE
 export const c_NAV_ACTIVE = c_NEON_PINK
+export const c_LOADING = c_NEON_YELLOW
 
 // Typography
 export const FONT_STACK = '"Renner*", sans-serif'

--- a/yarn.lock
+++ b/yarn.lock
@@ -3922,6 +3922,11 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
+custom-event@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/custom-event/-/custom-event-1.0.1.tgz#5d02a46850adf1b4a317946a3928fccb5bfd0425"
+  integrity sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=
+
 cwebp-bin@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cwebp-bin/-/cwebp-bin-5.1.0.tgz#d5bea87c127358558e7bf7a90a6d440d42dcb074"
@@ -8829,6 +8834,11 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
+lodash._getnative@^3.0.0:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
+  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
+
 lodash._reinterpolate@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -8869,6 +8879,16 @@ lodash.get@4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
+lodash.isarguments@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
+  integrity sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=
+
+lodash.isarray@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
+  integrity sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=
+
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
@@ -8878,6 +8898,15 @@ lodash.isstring@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
   integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
+
+lodash.keys@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
+  integrity sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=
+  dependencies:
+    lodash._getnative "^3.0.0"
+    lodash.isarguments "^3.0.0"
+    lodash.isarray "^3.0.0"
 
 lodash.map@^4.6.0:
   version "4.6.0"
@@ -11547,6 +11576,13 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-loading-bar@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/react-loading-bar/-/react-loading-bar-0.0.7.tgz#123d7765731b26d4aea21732817a2d6bb7e24ecb"
+  integrity sha512-0YfBXoYTS/lx7GJl+W+cV5hdCT5vyBY7DzC+SNPOnoC/oJVnTqgLUzovhZrV43weJeef6a0uWFuZ4ndtjBFptQ==
+  dependencies:
+    shallowequal "^0.2.2"
+
 react-malarquee@0.0.13:
   version "0.0.13"
   resolved "https://registry.yarnpkg.com/react-malarquee/-/react-malarquee-0.0.13.tgz#bb21fce6847c1646ee6516a5a295fb2a16d303ba"
@@ -12494,6 +12530,13 @@ shallow-compare@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/shallow-compare/-/shallow-compare-1.2.2.tgz#fa4794627bf455a47c4f56881d8a6132d581ffdb"
   integrity sha512-LUMFi+RppPlrHzbqmFnINTrazo0lPNwhcgzuAXVVcfy/mqPDrQmHAyz5bvV0gDAuRFrk804V0HpQ6u9sZ0tBeg==
+
+shallowequal@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-0.2.2.tgz#1e32fd5bcab6ad688a4812cb0cc04efc75c7014e"
+  integrity sha1-HjL9W8q2rWiKSBLLDMBO/HXHAU4=
+  dependencies:
+    lodash.keys "^3.1.2"
 
 shallowequal@^1.0.1, shallowequal@^1.0.2:
   version "1.1.0"


### PR DESCRIPTION
Fixes #228 

## Description

Events are dispatched from `gatsby_browser.js` when certain hooks are called. An event is dispatched when the history changes (i.e when the user clicks on a link, uses the backwards/forwards buttons etc.) to tell the loading bar to display, and another event is dispatched when the route changes (i.e. once the page has loaded and is displayed). The `wrapPageElement` hook allows the loading bar to display even during page change, but has to be mirrored in the server-side hooks for consistent behaviour between dev and production versions. 