### PR TITLE
fix #162: add focus styles which cycle the neon colours

### DIFF
--- a/src/components/Carousel/CarouselControl.js
+++ b/src/components/Carousel/CarouselControl.js
@@ -1,24 +1,35 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import classNames from 'classnames'
+import useFocusStyles from '../../focus'
 
 import { c_PRIMARY_TEXT } from '../../theme'
 
-const CarouselControl = ({ children, onClick, label }) => (
-  <button className="carousel_control" onClick={onClick} aria-label={label}>
-    {children}
-    <style jsx>{`
-      .carousel_control {
-        background: none;
-        border: 0;
-        font-family: inherit;
-        font-size: 2rem;
-        color: ${c_PRIMARY_TEXT};
-        cursor: pointer;
-        user-select: none;
-      }
-    `}</style>
-  </button>
-)
+const CarouselControl = ({ children, onClick, label }) => {
+  const focusStyle = useFocusStyles()
+
+  return (
+    <button
+      className={classNames('carousel_control', focusStyle.className)}
+      onClick={onClick}
+      aria-label={label}
+    >
+      {children}
+      <style jsx>{`
+        .carousel_control {
+          background: none;
+          border: 0;
+          font-family: inherit;
+          font-size: 2rem;
+          color: ${c_PRIMARY_TEXT};
+          cursor: pointer;
+          user-select: none;
+        }
+      `}</style>
+      {focusStyle.styles}
+    </button>
+  )
+}
 
 CarouselControl.propTypes = {
   children: PropTypes.node,

--- a/src/components/Carousel/CarouselImages.js
+++ b/src/components/Carousel/CarouselImages.js
@@ -2,30 +2,86 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Hexagon from '../Hexagon'
 import classNames from 'classnames'
+import useFocusStyles from '../../focus'
 
 import { breakpoint } from '../../theme'
+
+const CarouselImage = ({ image, i, activeImage, goToItem }) => {
+  const focusStyle = useFocusStyles()
+
+  return (
+    <div
+      className={classNames(
+        'carousel__image',
+        i === activeImage && 'carousel__image--is-active'
+      )}
+      key={image.src}
+    >
+      <button
+        className={classNames(
+          'carousel__image__button',
+          i === activeImage && 'carousel__image__button--is-active',
+          focusStyle.className
+        )}
+        onClick={() => goToItem(i)}
+        aria-label={`Go to item ${i + 1}`}
+      >
+        <Hexagon src={image.src} title={image.title} />
+        {focusStyle.styles}
+      </button>
+      <style jsx>{`
+        .carousel__image {
+          width: 100%;
+          display: none;
+          align-items: center;
+        }
+        .carousel__image--is-active {
+          display: flex;
+        }
+        .carousel__image__button {
+          width: 100%;
+          transform: scale(0.5);
+          background: none;
+          border: none;
+          height: auto;
+          padding: 0;
+          display: inline-block;
+          filter: grayscale(100%);
+          cursor: pointer;
+        }
+        .carousel__image__button--is-active {
+          transform: scale(1);
+          filter: none;
+        }
+
+        .carousel__image__button:not(.carousel__image__button--is-active):hover {
+          transform: scale(0.6);
+        }
+
+        @media (${breakpoint('sm')}) {
+          .carousel__image__button {
+            transition: all 0.2s ease-in-out;
+          }
+
+          .carousel__image {
+            width: 33.33%;
+            display: flex;
+          }
+        }
+      `}</style>
+    </div>
+  )
+}
 
 const CarouselImages = ({ images, activeImage, goToItem }) => (
   <div className="carousel__images">
     {images.map((image, i) => (
-      <div
-        className={classNames(
-          'carousel__image',
-          i === activeImage && 'carousel__image--is-active'
-        )}
-        key={image.src}
-      >
-        <button
-          className={classNames(
-            'carousel__image__button',
-            i === activeImage && 'carousel__image__button--is-active'
-          )}
-          onClick={() => goToItem(i)}
-          aria-label={`Go to item ${i + 1}`}
-        >
-          <Hexagon src={image.src} title={image.title} />
-        </button>
-      </div>
+      <CarouselImage
+        image={image}
+        i={i}
+        activeImage={activeImage}
+        goToItem={goToItem}
+      />
     ))}
 
     <style jsx>{`
@@ -37,44 +93,6 @@ const CarouselImages = ({ images, activeImage, goToItem }) => (
         position: relative;
         z-index: 1;
       }
-      .carousel__image {
-        width: 100%;
-        display: none;
-        align-items: center;
-      }
-      .carousel__image--is-active {
-        display: flex;
-      }
-      .carousel__image__button {
-        width: 100%;
-        transform: scale(0.5);
-        background: none;
-        border: none;
-        height: auto;
-        padding: 0;
-        display: inline-block;
-        filter: grayscale(100%);
-        cursor: pointer;
-      }
-      .carousel__image__button--is-active {
-        transform: scale(1);
-        filter: none;
-      }
-
-      .carousel__image__button:not(.carousel__image__button--is-active):hover {
-        transform: scale(0.6);
-      }
-
-      @media (${breakpoint('sm')}) {
-        .carousel__image__button {
-          transition: all 0.2s ease-in-out;
-        }
-
-        .carousel__image {
-          width: 33.33%;
-          display: flex;
-        }
-      }
     `}</style>
   </div>
 )
@@ -83,6 +101,11 @@ CarouselImages.propTypes = {
   images: PropTypes.array,
   activeImage: PropTypes.number,
   goToItem: PropTypes.func,
+}
+
+CarouselImage.propTypes = {
+  ...CarouselImages.propTypes,
+  i: PropTypes.number,
 }
 
 export default CarouselImages

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -3,9 +3,8 @@ import PropTypes from 'prop-types'
 import { c_PRIMARY_BACKGROUND_ALTERNATIVE, GUTTER_PX } from '../../theme'
 import ConstrainedWidth from '../Layout/ConstrainedWidth'
 import Text from '../Text'
-import { ExternalLink } from '../Link'
+import InternalLink, { ExternalLink } from '../Link'
 import Heading from '../Heading'
-import GatsbyLink from 'gatsby-link'
 import twitterlogo from './twitterlogo.svg'
 
 const mapListItems = children =>
@@ -60,11 +59,11 @@ export default () => (
             </ExternalLink>
           </li>
           <li>
-            <GatsbyLink to="/privacy-policy" title={`Link to privacy policy`}>
+            <InternalLink to="/privacy-policy" title={`Link to privacy policy`}>
               <Text lineHeight={2} alternate underline size="small">
                 Privacy Policy
               </Text>
-            </GatsbyLink>
+            </InternalLink>
           </li>
         </HousekeepingList>
         <HousekeepingList

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -101,9 +101,9 @@ const Header = () => (
   <ConstrainedWidth>
     <header className="header">
       <div className="logo-wrapper">
-        <GatsbyLink to="/" title={`Link to Neontribe homepage`}>
+        <Link to="/" title={`Link to Neontribe homepage`}>
           <Logo />
-        </GatsbyLink>
+        </Link>
       </div>
       <div className="nav-wrapper">
         <Nav />

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -6,6 +6,7 @@ import {
   c_PRIMARY_TEXT,
   c_PRIMARY_BACKGROUND,
   FONT_STACK,
+  c_NEONS,
 } from '../../theme'
 
 const Layout = ({ children }) => (

--- a/src/components/Link/ExternalLink.js
+++ b/src/components/Link/ExternalLink.js
@@ -1,20 +1,30 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
+import useFocusStyles from '../../focus'
 
 import { className, styles, LinkInternals } from './shared'
 
-const ExternalLink = ({ button, children, newTab, ...linkProps }) => (
-  <a
-    {...linkProps}
-    className={classNames(className, button && 'button')}
-    target={newTab ? '_blank' : '_self'}
-    rel="noopener noreferrer"
-  >
-    <LinkInternals button={button}>{children}</LinkInternals>
-    {styles}
-  </a>
-)
+const ExternalLink = ({ button, children, newTab, ...linkProps }) => {
+  const focusStyle = useFocusStyles()
+
+  return (
+    <a
+      {...linkProps}
+      className={classNames(
+        className,
+        button && 'button',
+        focusStyle.className
+      )}
+      target={newTab ? '_blank' : '_self'}
+      rel="noopener noreferrer"
+    >
+      <LinkInternals button={button}>{children}</LinkInternals>
+      {styles}
+      {focusStyle.styles}
+    </a>
+  )
+}
 
 ExternalLink.propTypes = {
   href: PropTypes.string.isRequired,

--- a/src/components/Link/InternalLink.js
+++ b/src/components/Link/InternalLink.js
@@ -5,15 +5,26 @@ import classNames from 'classnames'
 
 import { className, styles, LinkInternals } from './shared'
 
-const InternalLink = ({ button, children, ...linkProps }) => (
-  <GatsbyLink
-    {...linkProps}
-    className={classNames(className, button && 'button')}
-  >
-    <LinkInternals button={button}>{children}</LinkInternals>
-    {styles}
-  </GatsbyLink>
-)
+import useFocusStyles from '../../focus'
+
+const InternalLink = ({ button, children, ...linkProps }) => {
+  const focusStyle = useFocusStyles()
+
+  return (
+    <GatsbyLink
+      {...linkProps}
+      className={classNames(
+        className,
+        button && 'button',
+        focusStyle.className
+      )}
+    >
+      <LinkInternals button={button}>{children}</LinkInternals>
+      {styles}
+      {focusStyle.styles}
+    </GatsbyLink>
+  )
+}
 
 InternalLink.propTypes = {
   ...GatsbyLink.propTypes,

--- a/src/focus.js
+++ b/src/focus.js
@@ -1,0 +1,63 @@
+import React from 'react'
+import css from 'styled-jsx/css'
+import { c_NEONS } from './theme'
+
+let count = 0
+
+const generateFocus = num => {
+  if (typeof num !== 'number') {
+    num = count++
+  }
+
+  return {
+    ...css.resolve`
+      button:focus,
+      *[href]:focus,
+      input:focus,
+      select:focus,
+      textarea:focus,
+      *[tabindex]:not([tabindex='-1']):focus {
+        position: relative;
+        display: inline-block;
+        outline: none;
+      }
+
+      button:focus::before,
+      *[href]:focus::before,
+      input:focus::before,
+      select:focus::before,
+      textarea:focus::before,
+      *[tabindex]:not([tabindex='-1']):focus::before {
+        border: 1px solid white;
+        outline: 2px solid ${c_NEONS[num % c_NEONS.length]};
+        box-shadow: ${c_NEONS[num % c_NEONS.length]} 0px 0px 9px;
+        content: '';
+        position: absolute;
+        pointer-events: none;
+        display: block;
+        width: 100%;
+        height: 100%;
+        top: 0;
+        left: 0;
+      }
+    `,
+    newNum: num,
+  }
+}
+
+const useFocusStyles = () => {
+  const [num, setNum] = React.useState()
+
+  const { className, styles, newNum } = generateFocus(num)
+
+  React.useEffect(() => {
+    setNum(newNum)
+  }, [newNum])
+
+  return {
+    className,
+    styles,
+  }
+}
+
+export default useFocusStyles


### PR DESCRIPTION
Fixes #162 

## Description

This PR adds a `useFocusStyles` hook, which handles generating styles for any focussable element, as well as assigning it a colour to use for those styles. It also handles storing this allocated colour in the state in a attempt (in vain) to keep the colours the same between page loads.

This meant reorganizing `CarouselImages` into two components, `CarouselImages` (the containter) and `CarouselImage` (each individual item), which accounts for the 62% rewrite on that file.

See the acceptance criteria on #162 for additional details.