### PR TITLE
Title separator in website

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,7 +3,7 @@ module.exports = {
     defaultTitle: 'Welcome',
     siteUrl: 'https://www.neontribe.co.uk',
     siteName: 'Neontribe',
-    titleTemplate: '%s · Neontribe',
+    titleTemplate: '%s | Neontribe',
     description:
       'Neontribe is a digital agency. We learn from users, build something small, then measure how that’s helped. We hit deadlines, and make best use of your budget.',
     image: '/static/site-meta-image.png',


### PR DESCRIPTION
Fixes #252 

## Description

-changed the title separator from . to | .

## Criteria
-You can use screen readers (NVDA, ChromeVox) check if it still reading the symbol as 'times'.