### PR TITLE
Active page tab - Change background property for IE11

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -24,12 +24,12 @@ const activeLinkStyles = css.resolve`
     width: 100%;
     transform: rotate(180deg);
     background: 0 center repeat-x
-      url('data:image/svg+xml;utf-8,<?xml version="1.0" encoding="UTF-8"?>
-    <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="100%" height="8px" viewBox="0 0 9 6" enable-background="new 0 0 9 6" xml:space="preserve">
-        <polygon stroke="${encodeURIComponent(
+      url("data:image/svg+xml;charset=utf-8,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E
+    %3Csvg xmlns='http://www.w3.org/2000/svg' x='0px' y='0px' width='100%' height='8px' viewBox='0 0 9 6' enable-background='new 0 0 9 6' xml:space='preserve'%3E
+        %3Cpolygon stroke='${encodeURIComponent(
           c_NAV_ACTIVE
-        )}" points="4.5,4.5 0,0 0,1.208 4.5,5.708 9,1.208 9,0 "/>
-    </svg>');
+        )}' points='4.5,4.5 0,0 0,1.208 4.5,5.708 9,1.208 9,0 '/%3E
+    %3C/svg%3E");
   }
 `
 

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -27,6 +27,7 @@ const activeLinkStyles = css.resolve`
     background-position-y: center;
     background-repeat: repeat-x;
     background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' x='0px' y='0px' width='100%25' height='8px' viewBox='0 0 9 6' enable-background='new 0 0 9 6' xml:space='preserve'%3e%3cpolygon stroke='%23fb37f1' points='4.5,4.5 0,0 0,1.208 4.5,5.708 9,1.208 9,0 '/%3e%3c/svg%3e");
+    background-size: 12px 12px;
   }
 `
 

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -23,13 +23,10 @@ const activeLinkStyles = css.resolve`
     height: 8px;
     width: 100%;
     transform: rotate(180deg);
-    background: 0 center repeat-x
-      url("data:image/svg+xml;charset=utf-8,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E
-    %3Csvg xmlns='http://www.w3.org/2000/svg' x='0px' y='0px' width='100%' height='8px' viewBox='0 0 9 6' enable-background='new 0 0 9 6' xml:space='preserve'%3E
-        %3Cpolygon stroke='${encodeURIComponent(
-          c_NAV_ACTIVE
-        )}' points='4.5,4.5 0,0 0,1.208 4.5,5.708 9,1.208 9,0 '/%3E
-    %3C/svg%3E");
+    background-position-x: 0;
+    background-position-y: center;
+    background-repeat: repeat-x;
+    background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' x='0px' y='0px' width='100%25' height='8px' viewBox='0 0 9 6' enable-background='new 0 0 9 6' xml:space='preserve'%3e%3cpolygon stroke='%23fb37f1' points='4.5,4.5 0,0 0,1.208 4.5,5.708 9,1.208 9,0 '/%3e%3c/svg%3e");
   }
 `
 


### PR DESCRIPTION
Fixes #297 

## Description
Using a raw svg in the URL parameter of a background property in IE is a tricky thing. For example, background: `url('data:image/svg+xml;utf8,<svg ...> ... </svg>');` will work in popular browsers but IE won't tolerate it. For it to work, we have to HTML encode any URL-unsafe characters like `<`, `>` or `#`, swap attribute values' double quotes with single quotes, and wrap the URL with double quotes. For more, see [here](https://codepen.io/tigt/post/optimizing-svgs-in-data-uris).
-
-
