### PR TITLE
make IE carousel hexagons correct  size

### DIFF
--- a/src/components/Carousel/CarouselImages.js
+++ b/src/components/Carousel/CarouselImages.js
@@ -35,6 +35,10 @@ const CarouselImage = ({ image, i, activeImage, goToItem }) => {
           display: none;
           align-items: center;
         }
+        .carousel__image :global(svg) {
+          height: 300px !important;
+          width: 300px !important;
+        }
         .carousel__image--is-active {
           display: flex;
         }


### PR DESCRIPTION
Fixes #300 

## Description

It would be better if the `Hexagon` component handled this but I don't want to break anything else :slightly_smiling_face: 

* Tested in Chrome + IE11