### PR TITLE
avoid hexagon collision

### DIFF
--- a/src/components/Layout/Page.js
+++ b/src/components/Layout/Page.js
@@ -26,7 +26,13 @@ const Page = ({ title, children }) => (
         background-repeat: repeat-y;
         background-position: top left, top right;
 
-        /* scale background with viewport */
+        /**
+         * scale background with viewport 
+         *
+         * calc([minimum size] + ([maximum size] - [minimum size]) * ((100vw - [minimum viewport width]) / ([maximum viewport width] - [minimum viewport width])))
+         *
+         * https://css-tricks.com/snippets/css/fluid-typography
+         */
         background-size: calc(100px + (300 - 100) * ((100vw - 320px) / (1920 - 320)));
       }
 

--- a/src/components/Layout/Page.js
+++ b/src/components/Layout/Page.js
@@ -25,6 +25,9 @@ const Page = ({ title, children }) => (
         background-image: url('${hexagonsLeft}'), url('${hexagonsRight}');
         background-repeat: repeat-y;
         background-position: top left, top right;
+
+        /* scale background with viewport */
+        background-size: calc(100px + (300 - 100) * ((100vw - 320px) / (1920 - 320)));
       }
 
       main {

--- a/src/components/Link/shared.js
+++ b/src/components/Link/shared.js
@@ -1,7 +1,11 @@
 import React from 'react'
 import css from 'styled-jsx/css'
 
-import { c_CALL_TO_ACTION, c_PRIMARY_TEXT } from '../../theme'
+import {
+  c_PRIMARY_BACKGROUND,
+  c_CALL_TO_ACTION,
+  c_PRIMARY_TEXT,
+} from '../../theme'
 import Text from '../Text'
 import Arrow from './Arrow'
 
@@ -15,6 +19,7 @@ export const { className, styles } = css.resolve`
     display: inline-block;
     padding: 1rem 2rem;
     background-color: ${c_CALL_TO_ACTION};
+    box-shadow: 0 0 3px 3px ${c_PRIMARY_BACKGROUND};
   }
 `
 


### PR DESCRIPTION
Fixes #313 

## Description

* scale background hexagons with viewport
* add shadow around button controls

I've kept the hexagons large here to show the button shadow working:
![hex-background](https://user-images.githubusercontent.com/847033/68041254-16f00c00-fcc8-11e9-8425-a2fd68de9319.png)
