### PR TITLE
Update catch-up.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/catch-up.md
+++ b/.github/ISSUE_TEMPLATE/catch-up.md
@@ -6,9 +6,9 @@ labels: Project Management
 
 **Plan**
 
-- [ ] Review incomplete actions from #[previous catch-up]
-- [ ] Discuss any outstanding PRs
-- [ ] Go through the backlog/project board, order/review
+- [ ] Review incomplete actions from #[previous catch-up] and decide whether to carry over or change the action
+- [ ] Discuss any outstanding PRs and either approve, comment OR assign someone an action to review
+- [ ] Go through the to do list on the project board, order/review. IF list is short or down to low priority items or IF someone has asked the meeting to discuss a specific new issue, also review backlog for new candidates to bring forward.
 
 **Actions**
 


### PR DESCRIPTION
Updated, based on the 17th meeting where I was re-discovering how the process works. I felt the instructions could be clearer about what to do with the PRs when reviewing.  The change to the second statement around when to look at backlog or not felt like a way to stop us reviewing both the to do column AND the backlog at every single meeting?

Fixes #

## Description

-
-
