### PR TITLE
fix: tribe bio display on cards in safari

### DIFF
--- a/src/components/TribeMember/TribeMemberBack.js
+++ b/src/components/TribeMember/TribeMemberBack.js
@@ -13,6 +13,7 @@ const TribeMemberBack = ({
   bio,
   social,
   preventTabFocus,
+  display,
 }) => {
   const socialKeys = social ? Object.keys(social) : []
   var socialCount = 0
@@ -35,7 +36,7 @@ const TribeMemberBack = ({
             {skills.join(' | ')}
           </Text>
         </div>
-        <div className="back-content">{bio}</div>
+        {!preventTabFocus && <div className="back-content">{bio}</div>}
       </div>
 
       {socialCount ? (
@@ -75,6 +76,16 @@ const TribeMemberBack = ({
         .back-content {
           margin-top: 1em;
           overflow: auto;
+          animation: fadein 4s;
+        }
+
+        @keyframes fadein {
+          from {
+            opacity: 0;
+          }
+          to {
+            opacity: 1;
+          }
         }
 
         .social-icons {

--- a/src/components/TribeMember/TribeMemberBack.js
+++ b/src/components/TribeMember/TribeMemberBack.js
@@ -13,7 +13,7 @@ const TribeMemberBack = ({
   bio,
   social,
   preventTabFocus,
-  display,
+
 }) => {
   const socialKeys = social ? Object.keys(social) : []
   var socialCount = 0


### PR DESCRIPTION
Fixes #
**ONLY** in safari browser:
**In current site:** Tribe bio text appears before the white card is fully displayed. 
**In the new designs:** this bug is carried over leading to overflowing text displayed on the card front. 

Examples attached display  how the current bug impacts the new designs and how the code fixes this:



<img width="1680" alt="Screenshot 2022-11-06 at 18 38 04" src="https://user-images.githubusercontent.com/76073097/200189578-57c01830-fcc6-435c-aa1b-1bdb17d2e5f0.png">

<img width="1680" alt="Screenshot 2022-11-06 at 18 37 51" src="https://user-images.githubusercontent.com/76073097/200189583-76959851-4e25-479c-ae08-f7db2b17b893.png">


