### PR TITLE
Privacy policy

### DIFF
--- a/src/components/RenderContent.js
+++ b/src/components/RenderContent.js
@@ -4,13 +4,18 @@ import classNames from 'classnames'
 
 import Text from '../components/Text'
 import { ExternalLink } from '../components/Link'
-
-import arcs from './arcs.svg'
+import { c_NEON_PURPLE } from '../theme'
 
 const Content = (props) => (
   <>
     <div className="content" {...props} />
     <style jsx global>{`
+      .content {
+        background-color: white;
+        color: black;
+        padding: 2rem;
+      }
+
       .content * + * {
         margin-top: 1.5em;
       }
@@ -44,17 +49,7 @@ const Heading = ({ size, level, children, ...props }) => {
       <style jsx>{`
         .heading {
           display: inline-flex;
-        }
-
-        .with-arcs:before {
-          content: '';
-          display: block;
-          background-image: url('${arcs}');
-          background-position: left center;
-          background-repeat: no-repeat;
-          height: 2rem;
-          width: 2rem;
-          margin-right: 1.5rem;
+          color: ${c_NEON_PURPLE};
         }
       `}</style>
     </Text>
@@ -66,7 +61,7 @@ const RenderAst = ({ htmlAst, components = {}, children }) => {
     createElement: React.createElement,
     components: {
       h1: (props) => (
-        <Text align="center">
+        <Text>
           <Heading {...props} level={1} size="large" />
         </Text>
       ),

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -50,12 +50,4 @@ Text.propTypes = {
   paddingLeft: PropTypes.string,
 }
 
-Text.defaultProps = {
-  weight: '400',
-  align: 'inherit',
-  lineHeight: 'inherit',
-  size: 'inherit',
-  color: 'inheirt',
-}
-
 export default Text

--- a/src/data/pages/privacy.md
+++ b/src/data/pages/privacy.md
@@ -1,5 +1,3 @@
-# Neontribe Privacy Policy and Cookies
-
 This policy relates to www.neontribe.co.uk and related sub-domains of neontribe.co.uk (“the Site”) which is owned by Neontribe ltd and related activity.
 Neontribe ltd trading as Neontribe
 Registered as a limited company in England & Wales

--- a/src/pages/privacy-policy.js
+++ b/src/pages/privacy-policy.js
@@ -5,10 +5,41 @@ import { StaticQuery, graphql } from 'gatsby'
 import ConstrainedWidth from '../components/Layout/ConstrainedWidth'
 import { c_PRIMARY_BACKGROUND } from '../theme'
 import PageMeta from '../components/PageMeta'
+import PageTop from '../components/PageTop'
+import Text from '../components/Text'
+import Container from '../components/Container'
+import VerticalSpacing from '../components/VerticalSpacing'
+import circleArc from '../components/circleArc.svg'
 
-const NotFoundPage = () => (
+const PrivacyPolicy = () => (
   <Layout>
     <PageMeta title="Privacy" />
+
+    <PageTop>
+      <ConstrainedWidth>
+        <Container justifyContent="space-between" mobileFlexDirection="column">
+          <Text size="xlarge" color="#48e9ce">
+            <h1>Neontribe Privacy Policy </h1>
+          </Text>
+          <VerticalSpacing size={3} />
+
+          <div className="heading-arc">
+            <img src={circleArc} height={128} width={277} />{' '}
+          </div>
+        </Container>
+      </ConstrainedWidth>
+      <style jsx>{`
+        @media (max-width: 860px) {
+          .heading-arc {
+            padding-right: 0;
+            padding-top: 2rem;
+            align-self: center;
+          }
+        }
+      `}</style>
+    </PageTop>
+    <VerticalSpacing size={5}></VerticalSpacing>
+
     <StaticQuery
       query={graphql`
         query {
@@ -38,4 +69,4 @@ const NotFoundPage = () => (
   </Layout>
 )
 
-export default NotFoundPage
+export default PrivacyPolicy


### PR DESCRIPTION
Add styles to privacy policy. Should roughly match the designs for general page templates excluding the separation of content in white and light grey backgrounds:

<img width="1680" alt="Screenshot 2022-11-25 at 15 32 03" src="https://user-images.githubusercontent.com/76073097/204016705-79ff6ea6-5b01-49d6-b2ff-1fcbe57050bd.png">
