### PR TITLE
625 generate case study pages

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -21,6 +21,13 @@ module.exports = {
     {
       resolve: `gatsby-source-filesystem`,
       options: {
+        name: `case-studies`,
+        path: `${__dirname}/src/data/case-studies`,
+      },
+    },
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
         name: `projects`,
         path: `${__dirname}/src/data/projects`,
       },

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,42 +1,61 @@
-const path = require(`path`)
+const path = require('path')
 
 exports.createPages = async ({ actions, graphql }) => {
   const { createPage } = actions
-  const blogPostTemplate = path.resolve(`src/templates/blog-post.js`)
-  const result = await graphql(`
-    {
-      allMarkdownRemark(
-        limit: 1000
-        filter: { fields: { sourceName: { eq: "blog-posts" } } }
-      ) {
-        edges {
-          node {
-            frontmatter {
-              slug
-            }
-            fields {
-              sourceName
+
+  // General function to create pages
+  async function createPagesFromSource(sourceName, pathPrefix, templatePath) {
+    const template = path.resolve(templatePath)
+    const result = await graphql(`
+      {
+        allMarkdownRemark(
+          limit: 1000
+          filter: { fields: { sourceName: { eq: "${sourceName}" } } }
+        ) {
+          edges {
+            node {
+              frontmatter {
+                slug
+              }
+              fields {
+                sourceName
+              }
             }
           }
         }
       }
-    }
-  `)
+    `)
 
-  if (result.errors) {
-    throw result.errors
+    if (result.errors) {
+      throw result.errors
+    }
+
+    result.data.allMarkdownRemark.edges.forEach(({ node }) => {
+      createPage({
+        path: `${pathPrefix}/${node.frontmatter.slug}`,
+        component: template,
+        context: {
+          slug: node.frontmatter.slug,
+        },
+      })
+    })
   }
 
-  result.data.allMarkdownRemark.edges.forEach(({ node }) => {
-    createPage({
-      path: `blog/${node.frontmatter.slug}`,
-      component: blogPostTemplate,
-      context: {
-        slug: node.frontmatter.slug,
-      },
-    })
-  })
+  // Create pages for case studies
+  await createPagesFromSource(
+    'case-studies',
+    'case-studies',
+    'src/templates/case-study/index.js'
+  )
+
+  // Create pages for blog posts
+  await createPagesFromSource(
+    'blog-posts',
+    'blog',
+    'src/templates/blog-post.js'
+  )
 }
+
 // Support IE11 when running gatsby develop
 exports.onCreateWebpackConfig = function onCreateWebpackConfig({
   actions,

--- a/src/templates/case-study/index.js
+++ b/src/templates/case-study/index.js
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const CaseStudy = () => {
+  return <div>Placeholder for case study page template</div>
+}
+
+export default CaseStudy


### PR DESCRIPTION
# Feature for #625 
Adds logic that builds out case study pages from markdown files. Note that a placeholder template has been added to prevent the build from failing. 

## Description
- Adds case study path to gatsby  source file system config
- Refactors the git node to avoid code duplication

